### PR TITLE
Add backport package group

### DIFF
--- a/recipes-core/packagegroups/packagegroup-meta-python2-backport.bb
+++ b/recipes-core/packagegroups/packagegroup-meta-python2-backport.bb
@@ -1,0 +1,7 @@
+SUMMARY = "meta-python2-backport package group"
+
+inherit packagegroup
+
+RDEPENDS_${PN} = "\
+    python-pytest-timeout \
+"


### PR DESCRIPTION
Adds `packagegroup-meta-python2-backport` to build all recipes.