### PR TITLE
Add python-pytest-metadata

### DIFF
--- a/recipes-core/packagegroups/packagegroup-meta-python2-backport.bb
+++ b/recipes-core/packagegroups/packagegroup-meta-python2-backport.bb
@@ -4,4 +4,5 @@ inherit packagegroup
 
 RDEPENDS_${PN} = "\
     python-pytest-timeout \
+    python-pytest-metadata \
 "

--- a/recipes-devtools/python-pytest-metadata/python-pytest-metadata.inc
+++ b/recipes-devtools/python-pytest-metadata/python-pytest-metadata.inc
@@ -1,0 +1,9 @@
+SUMMARY = "Plugin for accessing test session metadata"
+DESCRIPTION = "pytest-metadata is a plugin for pytest that provides access to test session metadata."
+AUTHOR = "Dave Hunt <dhunt@mozilla.com>, Jim Brännlund <jimbrannlund@fastmail.com>"
+HOMEPAGE = "https://github.com/pytest-dev/pytest-metadata"
+BUGTRACKER = "https://github.com/pytest-dev/pytest-metadata/issues"
+SECTION = "development"
+LICENSE = "MPL-2.0"
+
+CVE_PRODUCT = ""

--- a/recipes-devtools/python-pytest-metadata/python-pytest-metadata/python2.patch
+++ b/recipes-devtools/python-pytest-metadata/python-pytest-metadata/python2.patch
@@ -1,0 +1,37 @@
+[PATCH] Support Python 2
+
+Changes for Python 2 compatibility
+
+Upstream-Status: Denied
+Signed-off-by: offa
+
+---
+diff --git a/setup.py b/setup.py
+--- /dev/null
++++ b/setup.py
+@@ -0,0 +1,22 @@
++import setuptools
++
++setuptools.setup(name="pytest-metadata",
++                 version="2.0.1",
++                 author='Dave Hunt',
++                 author_email='dhunt@mozilla.com',
++                 description="pytest plugin for test session metadata",
++                 url="https://github.com/pytest-dev/pytest-metadata",
++                 keywords=["pytest", "metadata"],
++                 classifiers=[
++                     "Development Status :: 5 - Production/Stable",
++                     "Framework :: Pytest",
++                     "Intended Audience :: Developers",
++                     "Operating System :: POSIX",
++                     "Operating System :: Microsoft :: Windows",
++                     "Operating System :: MacOS :: MacOS X",
++                     "Topic :: Software Development :: Quality Assurance",
++                     "Topic :: Software Development :: Testing",
++                     "Topic :: Utilities",
++                 ],
++                 packages=["src.pytest_metadata", "tests"],
++                 install_requires=['pytest>=3.0.0,<8.0.0'])
+diff --git a/src/__init__.py b/src/__init__.py
+new file mode 100644
+index 0000000..e69de29

--- a/recipes-devtools/python-pytest-metadata/python-pytest-metadata_2.0.1.bb
+++ b/recipes-devtools/python-pytest-metadata/python-pytest-metadata_2.0.1.bb
@@ -1,0 +1,19 @@
+require ${PN}.inc
+
+LIC_FILES_CHKSUM = "file://LICENSE;md5=5d425c8f3157dbf212db2ec53d9e5132"
+
+SRC_URI = "\
+    git://github.com/pytest-dev/pytest-metadata.git;protocol=https;nobranch=1 \
+    file://python2.patch \
+"
+SRCREV = "6216274eb9b74c23398f49f6bc4b7677542fb5e0"
+
+S = "${WORKDIR}/git"
+
+inherit setuptools
+PYPI_SOURCE_URI = "${SRC_URI}"
+
+RDEPENDS:${PN} += "\
+    python-pytest \
+"
+BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
The project doesn't contain a `setup.py` as used by the python2 layer, it's added by patch therefore.

closes #4 