### PR TITLE
Fail CI build on reported linter issues

### DIFF
--- a/.oelint.cfg
+++ b/.oelint.cfg
@@ -1,6 +1,5 @@
 [oelint]
 suppress =
     oelint.vars.homepageping
-exit-zero = True
 quiet = True
 color = True


### PR DESCRIPTION
Removes the `exit-zero` option, thus failing the CI build on reported issues.

closes #13 