### PR TITLE
Increase layer prio to 8

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -7,7 +7,7 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 
 BBFILE_COLLECTIONS += "meta-python2-backport"
 BBFILE_PATTERN_meta-python2-backport = "^${LAYERDIR}/"
-BBFILE_PRIORITY_meta-python2-backport = "5"
+BBFILE_PRIORITY_meta-python2-backport = "8"
 
 LAYERDEPENDS_meta-python2-backport = "core meta-python2"
 LAYERVERSION_meta-python2-backport = "1"


### PR DESCRIPTION
*meta-python2* uses a prio of 7, hiding recipes of this layer.