### PR TITLE
Remove unused 'PYPI_SOURCE_URI'

### DIFF
--- a/recipes-devtools/python-pytest-json-report/python-pytest-json-report_1.5.0.bb
+++ b/recipes-devtools/python-pytest-json-report/python-pytest-json-report_1.5.0.bb
@@ -11,7 +11,6 @@ SRCREV = "c6f0bc93a174770e04b965e459d339a880005e78"
 S = "${WORKDIR}/git"
 
 inherit setuptools
-PYPI_SOURCE_URI = "${SRC_URI}"
 
 RDEPENDS:${PN} += "\
     python-pytest \

--- a/recipes-devtools/python-pytest-metadata/python-pytest-metadata_1.11.0.bb
+++ b/recipes-devtools/python-pytest-metadata/python-pytest-metadata_1.11.0.bb
@@ -4,15 +4,12 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=5d425c8f3157dbf212db2ec53d9e5132"
 
 DEPENDS += "python-setuptools-scm-native"
 
-SRC_URI = "\
-    git://github.com/pytest-dev/pytest-metadata.git;protocol=https;nobranch=1 \
-"
+SRC_URI = "git://github.com/pytest-dev/pytest-metadata.git;protocol=https;nobranch=1"
 SRCREV = "a538cdee37b3f411d3fd865adfc60a8cb9b6033a"
 
 S = "${WORKDIR}/git"
 
 inherit setuptools
-PYPI_SOURCE_URI = "${SRC_URI}"
 
 RDEPENDS:${PN} += "python-pytest"
 

--- a/recipes-devtools/python-pytest-timeout/python-pytest-timeout_1.4.2.bb
+++ b/recipes-devtools/python-pytest-timeout/python-pytest-timeout_1.4.2.bb
@@ -2,15 +2,12 @@ require ${PN}.inc
 
 LIC_FILES_CHKSUM = "file://LICENSE;md5=d8048cd156eda3df2e7f111b0ae9ceff"
 
-SRC_URI = "\
-    git://github.com/pytest-dev/pytest-timeout.git;protocol=https;nobranch=1 \
-"
+SRC_URI = "git://github.com/pytest-dev/pytest-timeout.git;protocol=https;nobranch=1"
 SRCREV = "457e68aa2c4f2c901b190648ea940072e3826450"
 
 S = "${WORKDIR}/git"
 
 inherit setuptools
-PYPI_SOURCE_URI = "${SRC_URI}"
 
 RDEPENDS:${PN} += "\
     python-pytest \


### PR DESCRIPTION
`PYPI_SOURCE_URI` is unused as recipes inherit from `setuptools`.

closes #24 