### PR TITLE
python-importlib-metadata 2.1.3

### DIFF
--- a/recipes-core/packagegroups/packagegroup-meta-python2-backport.bb
+++ b/recipes-core/packagegroups/packagegroup-meta-python2-backport.bb
@@ -3,6 +3,7 @@ SUMMARY = "meta-python2-backport package group"
 inherit packagegroup
 
 RDEPENDS_${PN} = "\
+    python-importlib-metadata \
     python-pytest-json-report \
     python-pytest-metadata \
     python-pytest-timeout \

--- a/recipes-devtools/python-importlib-metadata/python-importlib-metadata.inc
+++ b/recipes-devtools/python-importlib-metadata/python-importlib-metadata.inc
@@ -1,0 +1,9 @@
+SUMMARY = "importlib_metadata is a library to access the metadata for a Python package."
+DESCRIPTION = "importlib_metadata is a library which provides an API for accessing an installed package’s metadata (see PEP 566), such as its entry points or its top-level name."
+AUTHOR = "Jason R. Coombs <jaraco@jaraco.com>"
+HOMEPAGE = "https://github.com/python/importlib_metadata"
+BUGTRACKER = "https://github.com/python/importlib_metadata/issues"
+SECTION = "development"
+LICENSE = "Apache-2.0"
+
+CVE_PRODUCT = ""

--- a/recipes-devtools/python-importlib-metadata/python-importlib-metadata_2.1.3.bb
+++ b/recipes-devtools/python-importlib-metadata/python-importlib-metadata_2.1.3.bb
@@ -1,0 +1,22 @@
+require ${PN}.inc
+
+LIC_FILES_CHKSUM = "file://LICENSE;md5=e88ae122f3925d8bde8319060f2ddb8e"
+
+DEPENDS += "python-setuptools-scm-native"
+
+SRC_URI = "git://github.com/python/importlib_metadata.git;protocol=https;nobranch=1"
+SRCREV = "611dd521b03b0b24628ae247107e8fb86c3c3919"
+
+S = "${WORKDIR}/git"
+
+inherit setuptools
+
+RDEPENDS:${PN} += "\
+    ${PYTHON_PN}-pathlib2 \
+    ${PYTHON_PN}-zipp \
+    python-compression \
+    python-configparser \
+    python-contextlib2 \
+    python-pathlib2 \
+"
+BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
Backport of python-importlib-metadata v2.1.3 – the last Python 2 version.

closes #21 