### PR TITLE
Remove setuptools_scm dependency of importlib-metadata

### DIFF
--- a/recipes-devtools/python-importlib-metadata/python-importlib-metadata/remove-setuptools_scm.patch
+++ b/recipes-devtools/python-importlib-metadata/python-importlib-metadata/remove-setuptools_scm.patch
@@ -1,0 +1,54 @@
+[PATCH] Remove setuptools_scm
+
+Remove setuptools_scm and use fixed version
+
+
+Inappropriate for submission due to EOL.
+
+Upstream-Status: Inappropriate [other]
+Signed-off-by: offa
+
+---
+diff --git a/pyproject.toml b/pyproject.toml
+index e5c3a6a..487e88f 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,2 +1,2 @@
+ [build-system]
+-requires = ["setuptools>=30.3", "wheel", "setuptools_scm"]
++requires = ["setuptools>=30.3", "wheel"]
+diff --git a/setup.cfg b/setup.cfg
+index fa10c8d..b10dbc7 100644
+--- a/setup.cfg
++++ b/setup.cfg
+@@ -16,7 +16,6 @@ classifiers =
+ 
+ [options]
+ python_requires = >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*
+-setup_requires = setuptools-scm
+ install_requires =
+     zipp>=0.5
+     pathlib2; python_version < '3'
+diff --git a/setup.py b/setup.py
+index d5d43d7..e838300 100644
+--- a/setup.py
++++ b/setup.py
+@@ -1,3 +1,3 @@
+ from setuptools import setup
+ 
+-setup(use_scm_version=True)
++setup(version="2.1.3")
+diff --git a/tox.ini b/tox.ini
+index 1f0e975..09d732b 100644
+--- a/tox.ini
++++ b/tox.ini
+@@ -75,7 +75,6 @@ deps =
+     wheel
+     setuptools
+     keyring
+-    setuptools_scm
+ passenv =
+     TWINE_PASSWORD
+ setenv =
+-- 
+

--- a/recipes-devtools/python-importlib-metadata/python-importlib-metadata_2.1.3.bb
+++ b/recipes-devtools/python-importlib-metadata/python-importlib-metadata_2.1.3.bb
@@ -2,9 +2,10 @@ require ${PN}.inc
 
 LIC_FILES_CHKSUM = "file://LICENSE;md5=e88ae122f3925d8bde8319060f2ddb8e"
 
-DEPENDS += "python-setuptools-scm-native"
-
-SRC_URI = "git://github.com/python/importlib_metadata.git;protocol=https;nobranch=1"
+SRC_URI = "\
+    git://github.com/python/importlib_metadata.git;protocol=https;nobranch=1 \
+    file://remove-setuptools_scm.patch \
+"
 SRCREV = "611dd521b03b0b24628ae247107e8fb86c3c3919"
 
 S = "${WORKDIR}/git"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-oelint-adv
+# oelint-adv #305: Broken Upstream Status reports
+oelint-adv==3.13.0


### PR DESCRIPTION
Do not set version through SCM infos, but use a fixed one.

:information_source: oelint reports missing Upstream Status (thus the build failure), but the status is set correctly.