### PR TITLE
Remove oelint downgrade workaround

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-# oelint-adv #305: Broken Upstream Status reports
-oelint-adv==3.13.0
+oelint-adv


### PR DESCRIPTION
Oelint 3.15.2 fixes the issue.

closes #28